### PR TITLE
Support for sealed shared scopes

### DIFF
--- a/src/org/mozilla/javascript/Context.java
+++ b/src/org/mozilla/javascript/Context.java
@@ -2481,7 +2481,7 @@ public class Context
         return cx;
     }
 
-    private Object compileImpl(Scriptable scope,
+    protected Object compileImpl(Scriptable scope,
                                String sourceString, String sourceName, int lineno,
                                Object securityDomain, boolean returnFunction,
                                Evaluator compiler,

--- a/src/org/mozilla/javascript/IdScriptableObject.java
+++ b/src/org/mozilla/javascript/IdScriptableObject.java
@@ -896,6 +896,7 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
      * @return obj casted to the target type
      * @throws EcmaError if the cast failed.
      */
+    @SuppressWarnings("unchecked")
     protected static <T> T ensureType(Object obj, Class<T> clazz, IdFunctionObject f)
     {
         if (clazz.isInstance(obj)) {

--- a/src/org/mozilla/javascript/ImporterTopLevel.java
+++ b/src/org/mozilla/javascript/ImporterTopLevel.java
@@ -103,9 +103,13 @@ public class ImporterTopLevel extends TopLevel {
 
     private Object getPackageProperty(String name, Scriptable start) {
         Object result = NOT_FOUND;
-        Object[] elements;
-        synchronized (importedPackages) {
-            elements = importedPackages.toArray();
+        Scriptable scope = start;
+        if (topScopeFlag) {
+            scope = ScriptableObject.getTopLevelScope(scope);
+        }
+        Object[] elements = getNativeJavaPackages(scope);
+        if (elements == null) {
+            return result;
         }
         for (int i=0; i < elements.length; i++) {
             NativeJavaPackage p = (NativeJavaPackage) elements[i];
@@ -119,7 +123,23 @@ public class ImporterTopLevel extends TopLevel {
                 }
             }
         }
+        
         return result;
+    }
+
+    private static Object[] getNativeJavaPackages(Scriptable scope) {
+        // retrive the native java packages stored in top scope.
+        synchronized (scope) {
+            if (scope instanceof ScriptableObject) {
+                ScriptableObject so = (ScriptableObject) scope;
+                ObjArray importedPackages = (ObjArray) so
+                        .getAssociatedValue(AKEY);
+                if (importedPackages != null) {
+                    return importedPackages.toArray();
+                }
+            }
+        }
+        return null;
     }
 
     /**
@@ -129,7 +149,7 @@ public class ImporterTopLevel extends TopLevel {
     public void importPackage(Context cx, Scriptable thisObj, Object[] args,
                               Function funObj)
     {
-        js_importPackage(args);
+        js_importPackage(this, args);
     }
 
     private Object js_construct(Scriptable scope, Object[] args)
@@ -138,9 +158,9 @@ public class ImporterTopLevel extends TopLevel {
         for (int i = 0; i != args.length; ++i) {
             Object arg = args[i];
             if (arg instanceof NativeJavaClass) {
-                result.importClass((NativeJavaClass)arg);
+                result.importClass(result, (NativeJavaClass)arg);
             } else if (arg instanceof NativeJavaPackage) {
-                result.importPackage((NativeJavaPackage)arg);
+                result.importPackage(result, (NativeJavaPackage)arg);
             } else {
                 throw Context.reportRuntimeErrorById(
                     "msg.not.class.not.pkg", Context.toString(arg));
@@ -156,7 +176,7 @@ public class ImporterTopLevel extends TopLevel {
         return result;
     }
 
-    private Object js_importClass(Object[] args)
+    private static Object js_importClass(Scriptable scope, Object[] args)
     {
         for (int i = 0; i != args.length; i++) {
             Object arg = args[i];
@@ -164,12 +184,12 @@ public class ImporterTopLevel extends TopLevel {
                 throw Context.reportRuntimeErrorById(
                     "msg.not.class", Context.toString(arg));
             }
-            importClass((NativeJavaClass)arg);
+            importClass(scope, (NativeJavaClass)arg);
         }
         return Undefined.instance;
     }
 
-    private Object js_importPackage(Object[] args)
+    private static Object js_importPackage(ScriptableObject scope, Object[] args)
     {
         for (int i = 0; i != args.length; i++) {
             Object arg = args[i];
@@ -177,17 +197,22 @@ public class ImporterTopLevel extends TopLevel {
                 throw Context.reportRuntimeErrorById(
                     "msg.not.pkg", Context.toString(arg));
             }
-            importPackage((NativeJavaPackage)arg);
+            importPackage(scope, (NativeJavaPackage)arg);
         }
         return Undefined.instance;
     }
 
-    private void importPackage(NativeJavaPackage pkg)
+    private static void importPackage(ScriptableObject scope, NativeJavaPackage pkg)
     {
         if(pkg == null) {
             return;
         }
-        synchronized (importedPackages) {
+        synchronized (scope) {
+            ObjArray importedPackages = (ObjArray) scope.getAssociatedValue(AKEY);
+            if (importedPackages == null) {
+                importedPackages = new ObjArray();
+                scope.associateValue(AKEY, importedPackages);
+            }
             for (int j = 0; j != importedPackages.size(); j++) {
                 if (pkg.equals(importedPackages.get(j))) {
                     return;
@@ -197,16 +222,16 @@ public class ImporterTopLevel extends TopLevel {
         }
     }
 
-    private void importClass(NativeJavaClass cl)
+    private static void importClass(Scriptable scope, NativeJavaClass cl)
     {
         String s = cl.getClassObject().getName();
         String n = s.substring(s.lastIndexOf('.')+1);
-        Object val = get(n, this);
+        Object val = scope.get(n, scope);
         if (val != NOT_FOUND && val != cl) {
             throw Context.reportRuntimeErrorById("msg.prop.defined", n);
         }
         //defineProperty(n, cl, DONTENUM);
-        put(n, this, cl);
+        scope.put(n, scope, cl);
     }
 
     @Override
@@ -236,22 +261,25 @@ public class ImporterTopLevel extends TopLevel {
             return js_construct(scope, args);
 
           case Id_importClass:
-            return realThis(thisObj, f).js_importClass(args);
+            return js_importClass(realScope(scope, thisObj, f), args);
 
           case Id_importPackage:
-            return realThis(thisObj, f).js_importPackage(args);
+            return js_importPackage(realScope(scope, thisObj, f), args);
         }
         throw new IllegalArgumentException(String.valueOf(id));
     }
 
-    private ImporterTopLevel realThis(Scriptable thisObj, IdFunctionObject f)
+    private ScriptableObject realScope(Scriptable scope, Scriptable thisObj, IdFunctionObject f)
     {
         if (topScopeFlag) {
             // when used as top scope importPackage and importClass are global
-            // function that ignore thisObj
-            return this;
+            // function that ignore thisObj. We use the the top level scope
+            // which might not be the same as 'this' when used shared scopes
+            scope = ScriptableObject.getTopLevelScope(scope);
+        } else {
+            scope = thisObj;
         }
-        return ensureType(thisObj, ImporterTopLevel.class, f);
+        return ensureType(thisObj, ScriptableObject.class, f);
     }
 
 // #string_id_map#
@@ -283,7 +311,6 @@ public class ImporterTopLevel extends TopLevel {
         MAX_PROTOTYPE_ID        = 3;
 
 // #/string_id_map#
-
-    private ObjArray importedPackages = new ObjArray();
+    private static final String AKEY = "importedPackages";
     private boolean topScopeFlag;
 }

--- a/src/org/mozilla/javascript/ImporterTopLevel.java
+++ b/src/org/mozilla/javascript/ImporterTopLevel.java
@@ -275,9 +275,7 @@ public class ImporterTopLevel extends TopLevel {
             // when used as top scope importPackage and importClass are global
             // function that ignore thisObj. We use the the top level scope
             // which might not be the same as 'this' when used shared scopes
-            scope = ScriptableObject.getTopLevelScope(scope);
-        } else {
-            scope = thisObj;
+            thisObj = ScriptableObject.getTopLevelScope(scope);
         }
         return ensureType(thisObj, ScriptableObject.class, f);
     }

--- a/src/org/mozilla/javascript/NativeJavaMap.java
+++ b/src/org/mozilla/javascript/NativeJavaMap.java
@@ -96,9 +96,13 @@ public class NativeJavaMap extends NativeJavaObject {
         }
         
         Object ret = keyTranslationMap.get(key);
-        if (ret == null && translateNew) {
-            ret = Context.jsToJava(key, keyType);
-            keyTranslationMap.put(key, ret);
+        if (ret == null) {
+            if (translateNew) {
+                ret = Context.jsToJava(key, keyType);
+                keyTranslationMap.put(key, ret);
+            } else {
+                ret = key;
+            }
         }
         return ret;
     }

--- a/src/org/mozilla/javascript/NativeJavaMap.java
+++ b/src/org/mozilla/javascript/NativeJavaMap.java
@@ -75,9 +75,10 @@ public class NativeJavaMap extends NativeJavaObject {
 
     @Override
     public Object get(int index, Scriptable start) {
-        if (map.containsKey(toKey(index, false))) {
+      Object key = toKey(Integer.valueOf(index), false);
+        if (map.containsKey(key)) {
             Context cx = Context.getContext();
-            Object obj = map.get(Integer.valueOf(index));
+            Object obj = map.get(key);
             if (obj == null) {
                 return null;
             }
@@ -86,20 +87,42 @@ public class NativeJavaMap extends NativeJavaObject {
         return super.get(index, start);
     }
     
-    private Object toKey(String key, boolean translateNew) {
-        if (keyType == String.class) {
+    @SuppressWarnings("unchecked")
+    private Object toKey(Object key, boolean translateNew) {
+        if (keyType == String.class || map.containsKey(key)) {
+            // fast exit, if we know, that there are only string keys in the map o
             return key;
         }
+        String strKey = ScriptRuntime.toString(key);
+        if (map.containsKey(strKey)) {
+            // second fast exit, if the key is present as string.
+            return strKey;
+        }
+
+        // TODO: There is no change detection yet. The keys in the wrapped map could theoretically
+        // change though other java code. To reduce this risk, we clear the keyTranslationMap on
+        // unwrap. An approach to track if the underlying map was changed may be to read the
+        // 'modCount' property of HashMap, but this is not part of the Map interface.
+        // So for now, wrapped maps must not be changed by external code.
         if (keyTranslationMap == null) {
             keyTranslationMap = new HashMap<>();
             map.keySet().forEach(k -> keyTranslationMap.put(ScriptRuntime.toString(k), k));
         }
-        
-        Object ret = keyTranslationMap.get(key);
+        Object ret = keyTranslationMap.get(strKey);
         if (ret == null) {
             if (translateNew) {
-                ret = Context.jsToJava(key, keyType);
-                keyTranslationMap.put(key, ret);
+                // we do not have the key, and we need a new one, (due PUT operation e.g.)
+                if (keyType == Object.class) {
+                    // if we do not know the keyType, just pass through the key
+                    ret = key;
+                } else if (Enum.class.isAssignableFrom(keyType)) {
+                    // for enums use "valueOf" method
+                    ret = Enum.valueOf((Class) keyType, strKey);
+                } else {
+                    // for all other use jsToJava (which might run into a conversionError)
+                    ret = Context.jsToJava(key, keyType);
+                }
+                keyTranslationMap.put(strKey, ret);
             } else {
                 ret = key;
             }
@@ -107,12 +130,12 @@ public class NativeJavaMap extends NativeJavaObject {
         return ret;
     }
     
-    private Object toKey(int key, boolean translateNew) {
-        return toKey(ScriptRuntime.toString(key), translateNew);
-    }
-    
     private Object toValue(Object value) {
-        return Context.jsToJava(value, valueType);
+        if (valueType == Object.class) {
+            return value;
+        } else {
+            return Context.jsToJava(value, valueType);
+        }
     }
 
     @Override
@@ -125,6 +148,13 @@ public class NativeJavaMap extends NativeJavaObject {
         map.put(toKey(index, true), toValue(value));
     }
 
+    @Override
+    public Object unwrap() {
+        // clear keyTranslationMap on unwrap, as native java code may modify the object now
+        keyTranslationMap = null;
+        return super.unwrap();
+    }
+    
     @Override
     public Object[] getIds() {
         Object[] ids = new Object[map.size()];

--- a/src/org/mozilla/javascript/TopLevel.java
+++ b/src/org/mozilla/javascript/TopLevel.java
@@ -32,7 +32,7 @@ import java.util.EnumMap;
  * built-in classes after initialization. For other setups involving
  * top-level scopes that inherit global properties from their proptotypes
  * (e.g. with dynamic scopes) embeddings should explicitly call
- * {@link #cacheBuiltins()} to initialize the class cache for each top-level
+ * {@link #cacheBuiltins(Scriptable, boolean)} to initialize the class cache for each top-level
  * scope.</p>
  */
 public class TopLevel extends IdScriptableObject {
@@ -222,7 +222,7 @@ public class TopLevel extends IdScriptableObject {
 
     /**
      * Get the cached built-in object constructor from this scope with the
-     * given <code>type</code>. Returns null if {@link #cacheBuiltins()} has not
+     * given <code>type</code>. Returns null if {@link #cacheBuiltins(Scriptable, boolean)} has not
      * been called on this object.
      * @param type the built-in type
      * @return the built-in constructor
@@ -244,7 +244,7 @@ public class TopLevel extends IdScriptableObject {
 
     /**
      * Get the cached built-in object prototype from this scope with the
-     * given <code>type</code>. Returns null if {@link #cacheBuiltins()} has not
+     * given <code>type</code>. Returns null if {@link #cacheBuiltins(Scriptable, boolean)} has not
      * been called on this object.
      * @param type the built-in type
      * @return the built-in prototype

--- a/src/org/mozilla/javascript/WrapFactory.java
+++ b/src/org/mozilla/javascript/WrapFactory.java
@@ -104,7 +104,7 @@ public class WrapFactory
      * Wrap Java object as Scriptable instance to allow full access to its
      * methods and fields from JavaScript.
      * <p>
-     * {@link #wrap(Context, Scriptable, Object, Class)} and
+     * {@link #wrap(Context, Scriptable, Object, Type)} and
      * {@link #wrapNewObject(Context, Scriptable, Object)} call this method
      * when they can not convert <code>javaObject</code> to JavaScript primitive
      * value or JavaScript array.

--- a/testsrc/org/mozilla/javascript/tests/NativeJavaMapTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeJavaMapTest.java
@@ -26,6 +26,10 @@ public class NativeJavaMapTest extends TestCase {
     public NativeJavaMapTest() {
         global.init(ContextFactory.getGlobal());
     }
+    
+    public static enum MyEnum {
+      A, B, C, X, Y, Z
+    }
 
 
     public void testAccessingJavaMapIntegerValues() {
@@ -37,7 +41,60 @@ public class NativeJavaMapTest extends TestCase {
         assertEquals(2, runScriptAsInt("value[1]", map));
         assertEquals(3, runScriptAsInt("value[2]", map));
     }
+    public void testAccessingJavaMapLongValues() {
+      Map<Number, Number> map = new HashMap<>();
+      map.put(0L, 1);
+      map.put(1L, 2);
+      map.put(2L, 3);
+      
+      assertEquals(2, runScriptAsInt("value[1]", map));
+      assertEquals(3, runScriptAsInt("value[2]", map));
+      runScriptAsString("value[4] = 4.01", map);
+      assertEquals(Double.valueOf(4.01), map.get(4)); 
+      assertEquals(null, map.get(4L)); 
+    }
+    
+    public void testAccessingJavaMapEnumValuesWithGeneric() {
+      // genrate inner class, that contains type information.
+      Map<MyEnum, Integer> map = new HashMap<MyEnum, Integer>() {
+        private static final long serialVersionUID = 1L;
+      };
+      
+      map.put(MyEnum.A, 1);
+      map.put(MyEnum.B, 2);
+      map.put(MyEnum.C, 3);
+      
+      assertEquals(2, runScriptAsInt("value['B']", map));
+      assertEquals(3, runScriptAsInt("value['C']", map));
+      runScriptAsString("value['X'] = 4.01", map);
+      // we know the type info and can convert the key to Long and the value is rounded to Integer
+      assertEquals(Integer.valueOf(4),map.get(MyEnum.X)); 
+      
+      try {
+        runScriptAsString("value['D'] = 4.0", map);
+        fail();;
+      } catch (IllegalArgumentException ex) {
+        assertEquals("No enum constant org.mozilla.javascript.tests.NativeJavaMapTest.MyEnum.D", ex.getMessage());
+      }
+    }
 
+    public void testAccessingJavaMapLongValuesWithGeneric() {
+      // genrate inner class, that contains type information.
+      Map<Long, Integer> map = new HashMap<Long, Integer>() {
+        private static final long serialVersionUID = 1L;
+      };
+      
+      map.put(0L, 1);
+      map.put(1L, 2);
+      map.put(2L, 3);
+      
+      assertEquals(2, runScriptAsInt("value[1]", map));
+      assertEquals(3, runScriptAsInt("value[2]", map));
+      runScriptAsInt("value[4] = 4.0", map);
+      // we know the type info and can convert the key to Long and the value to Integer
+      assertEquals(Integer.valueOf(4),map.get(4L)); 
+      assertEquals(null, map.get(4));
+    }
     public void testJavaMethodCalls() {
         Map<String, Number> map = new HashMap<>();
         map.put("a", 1);

--- a/testsrc/org/mozilla/javascript/tests/SealedSharedScopeTest.java
+++ b/testsrc/org/mozilla/javascript/tests/SealedSharedScopeTest.java
@@ -1,0 +1,166 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Locale;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.EcmaError;
+import org.mozilla.javascript.EvaluatorException;
+import org.mozilla.javascript.IdFunctionObject;
+import org.mozilla.javascript.ImporterTopLevel;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.Wrapper;
+
+@RunWith(BlockJUnit4ClassRunner.class)
+public class SealedSharedScopeTest {
+
+    private Context ctx;
+    private ImporterTopLevel sharedScope;
+    private Scriptable scope1;
+    private Scriptable scope2;
+
+    @Before
+    public void setUp() throws Exception {
+        Context tmpCtx = Context.enter();
+        sharedScope = new ImporterTopLevel(tmpCtx, true);
+        sharedScope.sealObject();
+        Context.exit();
+
+        ctx = Context.enter();
+        scope1 = ctx.newObject(sharedScope);
+        scope1.setPrototype(sharedScope);
+        scope1.setParentScope(null);
+        scope2 = ctx.newObject(sharedScope);
+        scope2.setPrototype(sharedScope);
+        scope2.setParentScope(null);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Context.exit();
+    }
+
+    private Object evaluateString(Scriptable scope, String source) {
+        Object o = ctx.evaluateString(scope, source, "test", 1, null);
+        if (o instanceof Wrapper) {
+            o = ((Wrapper) o).unwrap();
+        }
+        return o;
+    }
+
+    /**
+     * Test should verify if JavaImporter can import
+     * java.util.Date/java.sql.Date without colliding with internal Date
+     * function.
+     */
+    @Test
+    public void importClassWithImporter() throws Exception {
+        Object o;
+        evaluateString(scope1, "var imp1 = new JavaImporter();\n"
+                + "imp1.importClass(java.util.Date);");
+        evaluateString(scope1, "var imp2 = new JavaImporter();\n"
+                + "imp2.importClass(java.sql.Date);");
+        o = evaluateString(scope1, "imp1.Date");
+        assertEquals(java.util.Date.class, o);
+
+        o = evaluateString(scope1, "imp2.Date");
+        assertEquals(java.sql.Date.class, o);
+
+        o = evaluateString(scope1, "Date"); // JavaScript "Statement" function
+        assertEquals(IdFunctionObject.class, o.getClass());
+
+        o = evaluateString(scope2, "typeof imp1"); // scope 2 has
+                                                                  // no imp1
+        assertEquals("undefined", o);
+    }
+
+    /**
+     * Test should verify if JavaImporter can import
+     * java.util.Date/java.sql.Date without colliding with internal Date
+     * function.
+     */
+    @Test
+    public void importPackageWithImporter() throws Exception {
+        Object o;
+        evaluateString(scope1, "var imp1 = new JavaImporter();\n"
+                + "imp1.importPackage(java.util);");
+        evaluateString(scope1, "var imp2 = new JavaImporter();\n"
+                + "imp2.importPackage(java.sql);");
+        o = evaluateString(scope1, "imp1.Date");
+        assertEquals(java.util.Date.class, o);
+
+        o = evaluateString(scope1, "imp2.Date");
+        assertEquals(java.sql.Date.class, o);
+
+        o = evaluateString(scope1, "Date"); // JavaScript "Statement" function
+        assertEquals(IdFunctionObject.class, o.getClass());
+
+        o = evaluateString(scope2, "typeof imp1 == 'undefined'"); // scope 2 has
+                                                                  // no imp1
+        assertTrue((Boolean) o);
+    }
+
+    @Test
+    public void importClassWithScope() throws Exception {
+        Object o;
+        evaluateString(scope1, "importClass(javax.naming.Name);");
+        evaluateString(scope2, "importClass(javax.xml.soap.Name);");
+        o = evaluateString(scope1, "Name");
+        assertEquals(javax.naming.Name.class, o);
+
+        o = evaluateString(scope2, "Name");
+        assertEquals(javax.xml.soap.Name.class, o);
+
+        o = evaluateString(sharedScope, "typeof Name"); // JavaScript "Statement"
+                                                 // function
+        assertEquals("undefined", o);
+    }
+
+    @Test
+    public void importPackageWithScope() throws Exception {
+        Object o;
+        evaluateString(scope1, "importPackage(javax.naming);");
+        evaluateString(scope2, "importPackage(javax.xml.soap);");
+        o = evaluateString(scope1, "Name");
+        assertEquals(javax.naming.Name.class, o);
+
+        o = evaluateString(scope2, "Name");
+        assertEquals(javax.xml.soap.Name.class, o);
+
+        o = evaluateString(sharedScope, "typeof Name"); // JavaScript "Statement"
+                                                 // function
+        assertEquals("undefined", o);
+    }
+
+    @Test(expected = EvaluatorException.class)
+    public void importClassFailsOnSealedScope() throws Exception {
+        evaluateString(sharedScope, "importClass(java.util.Locale);");
+    }
+
+    @Test
+    public void importClassSucceedsOnScope() throws Exception {
+        evaluateString(scope1, "importClass(java.util.Locale);");
+        Object o = evaluateString(scope1, "Locale.getDefault()");
+        assertEquals(Locale.getDefault(), o);
+        try {
+            evaluateString(scope2, "Locale.getDefault()");
+            fail("EcmaError expected");
+        } catch (EcmaError e) {
+            assertEquals("ReferenceError: \"Locale\" is not defined. (test#1)",
+                    e.getMessage());
+        }
+    }
+
+}


### PR DESCRIPTION
This commt adds the ability to seal a shared scope.

Old behaviour:
`importClass` and `importPackage` tries to store the class/package information in the shared context. So sealing the shared context is not possible.

New behaviour:
Store the info in the topmost context (which is not the prototype shared context)