### PR TITLE
Improve Android detection to support both Dalvik and ART

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/AndroidCompat.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AndroidCompat.java
@@ -6,18 +6,11 @@
 
 package org.mozilla.javascript;
 
-/**
- * Simple Android compatibility helper.
- *
- * <p>Provides minimal Android detection for automatic interpreter mode selection.
- */
 class AndroidCompat {
-
     private static final boolean IS_ANDROID = checkAndroid();
 
     private static boolean checkAndroid() {
         try {
-            // More reliable than checking VM name - detects both Dalvik and ART
             Class.forName("android.os.Build");
             return true;
         } catch (ClassNotFoundException e) {
@@ -25,7 +18,6 @@ class AndroidCompat {
         }
     }
 
-    /** Returns true if running on Android. */
     static boolean isAndroid() {
         return IS_ANDROID;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/AndroidCompat.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AndroidCompat.java
@@ -1,0 +1,32 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript;
+
+/**
+ * Simple Android compatibility helper.
+ *
+ * <p>Provides minimal Android detection for automatic interpreter mode selection.
+ */
+class AndroidCompat {
+
+    private static final boolean IS_ANDROID = checkAndroid();
+
+    private static boolean checkAndroid() {
+        try {
+            // More reliable than checking VM name - detects both Dalvik and ART
+            Class.forName("android.os.Build");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    /** Returns true if running on Android. */
+    static boolean isAndroid() {
+        return IS_ANDROID;
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/Context.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Context.java
@@ -2652,7 +2652,7 @@ public class Context implements Closeable {
     }
 
     private static Class<?> codegenClass =
-            "Dalvik".equals(System.getProperty("java.vm.name"))
+            AndroidCompat.isAndroid()
                     ? null
                     : Kit.classOrNull("org.mozilla.javascript.optimizer.Codegen");
     private static Class<?> interpreterClass =


### PR DESCRIPTION
Improves Android detection to work with both Dalvik and ART runtimes.

Uses `android.os.Build` class detection instead of VM name checking - more robust and future-proof since ART became default in Android 5.0 (2014).

Builds on your excellent work\!